### PR TITLE
add remote server to configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It is further possible to roll out playbooks.
 | attackmate_msf_passwd          | password | **None** | Password for the Metasploit rpcd. (only needed for msf-commands) |
 | attackmate_playwright          | bool         | True | Whether to install Playwright and its dependencies |
 | command_delay                  | float | **None** | delay in seconds before commands for the CommandConfig |
+| attackmate_remote_config | dict | {} | Optional map of named remote AttackMate connections. Each entry requires url, username, password, and optionally cafile. If empty, no remote_config section is written to the config file. |
 
 ## Example Playbook
 
@@ -51,6 +52,12 @@ It is further possible to roll out playbooks.
           - upgradeshell.j2
           - attackchain.j2
         command_delay: 2
+        attackmate_remote_config:
+          primary_node:
+            url: "https://10.0.0.5:5000"
+            username: admin
+            password: securepassword
+            cafile: "/path/to/cert.pem"
 ```
 
 This role installs to executables:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,17 @@ attackmate_playwright_pip_packages:  # Python packages to install into the Attac
 
 grpc_download_base_url: "https://aecidimages.ait.ac.at/EXTRA/grpc"
 distribution_lower: "{{ ansible_distribution | lower }}"
+
+# Remote AttackMate connections (optional)
+# attackmate_remote_config:
+#   remote_server:
+#     url: "https://10.0.0.5:5000"
+#     username: admin
+#     password: securepassword
+#     cafile: "/path/to/cert.pem"
+#   another_server:
+#     url: "https://10.0.0.6:5000"
+#     username: user
+#     password: anotherpassword
+#     cafile: "/path/to/another_cert.pem"
+attackmate_remote_config: {}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -28,7 +28,6 @@ platforms:
 provisioner:
   name: ansible
   env:
-    ANSIBLE_ROLES_PATH: "/home/ubuntu/aecid_roles/"
     ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "True"
 verifier:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -27,7 +27,9 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-  ANSIBLE_ROLES_PATH: "/home/ubuntu/aecid_roles/"
+  env:
+    ANSIBLE_ROLES_PATH: "/home/ubuntu/aecid_roles/"
+    ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "True"
 verifier:
   name: ansible
 scenario:

--- a/templates/attackmate.yml.j2
+++ b/templates/attackmate.yml.j2
@@ -21,3 +21,16 @@ msf_config:
 cmd_config:
   command_delay: {{ command_delay }}
 {% endif %}
+
+{% if attackmate_remote_config %}
+remote_config:
+{% for name, conn in attackmate_remote_config.items() %}
+  {{ name }}:
+    url: "{{ conn.url }}"
+    username: {{ conn.username }}
+    password: {{ conn.password }}
+{% if conn.cafile is defined %}
+    cafile: "{{ conn.cafile }}"
+{% endif %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Adds support for configuring remote AttackMate connections via the new  `attackmate_remote_config` variable. 
When defined, the Jinja2 template renders a `remote_config` block in `attackmate.yml `with one or more named connections.
Each connections consists of url, username, password, and cafile. 
The `attackmate_remote_config` variable defaults to an empty dict, i.e. no connection config configured by default

Example:

Install playbook 
```yaml
- name: Install attackmate
  become: true
  hosts: localhost
  roles:
    - role: /home/boenket/Documents/projects/attackmate-ansible
      vars:
        attackmate_remote_config:
         remote_server:
           url: "https://10.0.0.5:5000"
           username: admin
           password: securepassword
           cafile: "/path/to/cert.pem"
        command_delay: 1
```

Resulting config: 
```yaml
###
cmd_config:
  command_delay: 1

remote_config:
  remote_server:
    url: "https://10.0.0.5:5000"
    username: admin
    password: securepassword
    cafile: "/path/to/cert.pem"
```

Additionally 
- fixes ansible errors due to strict type checking in newer ansible version, that no longer allows string values in boolean conditionals. (happens in docker driver of molecule plugin)
-  removes ansible role path (molecule automatically searches up the hierarchy