### PR TITLE
Install as api server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ It is further possible to roll out playbooks.
 
 ## Requirements
 
-- Debian or Ubuntu
+- Debian 13 
+
+- Ubuntu 24.04 
+
+- Kali Linux (Rolling)
+
+
+Note on gRPC: To ensure high performance and fast deployment, pre-compiled Python wheels (.whl) for grpc are automatically fetched by the role from our internal image server for the distributions listed above. For other operating systems, the role will fallback to compiling gRPC locally, which may significantly increase the initial setup time.
 
 (Currently there are no packages defined for RedHat distributions)
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,28 @@ It is further possible to roll out playbooks.
 | attackmate_playwright          | bool         | True                                      | Whether to install Playwright and its dependencies |
 | command_delay                  | float        | **None**                                  | delay in seconds before commands for the CommandConfig |
 | attackmate_remote_config       | dict         | {} | Optional map of named remote AttackMate connections. Each entry requires url, username, password, and optionally cafile. If empty, no remote_config section is written to the config file.|
+
+## Additional role Variables for installation as Api server 
+| Variable name                  | Type         | Default                                   | Description                                              |
+| ------------------------------ | ------------ | ----------------------------------------- | -------------------------------------------------------- |
 | attackmate_api_server          | bool         | False                                     | Install the attackmate-api-server |
 | attackmate_api_server_url      | url          | https://github.com/ait-testbed/attackmate-api-server.git | Repository URL for the api server |
 | attackmate_api_server_version  | version-str  | main                                      | Version/Branch of the api server repository |
 | attackmate_api_server_dest     | path         | {{ attackmate_shared_dir }}/attackmate-api-server | Installation path of the api server |
+| attackmate_api_bin_path        | path         | /usr/local/bin/attackmate-api | Installation path for the attackmate-api executable |
+| attackmate_api_service_path    | path         | /etc/systemd/system/attackmate-api.service | Path for the systemd service unit file |
+| attackmate_api_log_dir         | path         | /var/log/attackmate-api | Directory for API server log files |
+| attackmate_api_logs_to_disk    | bool         | False | Whether to write playbook logs to disk |
+| attackmate_ssl_key_path        | path         | /etc/ssl/private/attackmate.key | Path for the generated RSA private key |
+| attackmate_ssl_cert_path       | path         | /etc/ssl/certs/attackmate.pem | Path for the generated self-signed certificate |
+| attackmate_api_plain_ users    | dict         | {} | Map of username to plaintext password used to generate argon2 hashes at deploy time. Format: {"username": "password", ...}. Leave empty to skip user generation. Never commit plaintext passwords! |
+
+
+> [!WARNING]
+> `attackmate_api_plain_users` contains plaintext passwords and must **never** be committed to version control.
+> Only define this variable locally on the machine you are running the playbook from, either by passing it via
+> `--extra-vars` at runtime or in a local vars file that is excluded from your repository via `.gitignore`.
+> The hashing and deployment happen in memory only — the plaintext passwords are never written to the target host.
 
 ## Example Playbook
 
@@ -85,11 +103,14 @@ To enable the API server, set `attackmate_api_server: True` in your playbook:
     - role: attackmate
       vars:
         attackmate_api_server: True
+        attackmate_api_plain_users:
+          admin: "securepassword"
+
 ```
 
  installs to executables:
 
-* **/usr/local/bin/attackmate-api-server**: a wrapper for attackmate that uses the virtual environment
+* **/usr/local/bin/attackmate-api-server**: symlink to the attackmate-api-server executable in the virtual environment
 
 ## Role testing with molecule
 

--- a/README.md
+++ b/README.md
@@ -14,26 +14,30 @@ It is further possible to roll out playbooks.
 
 | Variable name                  | Type         | Default                                   | Description                                              |
 | ------------------------------ | ------------ | ----------------------------------------- | -------------------------------------------------------- |
-| attackmate_url                 | url          | https://github.com/ait-aecid/attackmate.git | Official attackmate repository |
-| attackmate_version             | version-str  | main | Version/Branch of the Git-Repository in attackmate_url |
-| attackmate_shared_dir          | path         | /usr/local/share | Installation path |
-| attackmate_dest                | path         | `{{ attackmate_shared_dir }}/attackmate` | Installation path of the attackmate repository |
-| attackmate_sliverfix           | bool         | True | [Install sliver-fix](https://aeciddocs.ait.ac.at/attackmate/development/installation/sliverfix.html#sliver-fix) |
-| attackmate_grpc_dest           | path | `{{ attackmate_shared_dir }}/grpc` | Temporary install grpc to this path if sliverfix is enabled |
-| attackmate_bindir              | path | /usr/local/bin | Installpath for the tmux-wrapper |
-| attackmate_tmux                | bool | True | Deploy tmux-wrapper |
-| attackmate_tmux_session        | str  | attackmate | Use this existing session-name for the tmux-wrapper |
-| attackmate_tmux_window         | str  | attackmate | The name of the tmux-window for attackmate |
-| attackmate_config_dir          | path | /etc/attackmate | Path to the config-directory |
-| attackmate_playbook_path       | path | `{{ attackmate_config_dir }}/playbooks` | Path to the playbooks-directory |
-| attackmate_playbooks           | list of playbook-templates(j2) | `[]` | List of playbooks to deploy |
-| attackmate_config_tpl          | str  | attackmate.yml.j2 | Name of the config-template(jinja) |
-| attackmate_sliver_config       | path | **None** | Path to the generated sliver-config. (only needed for sliver-commands) |
-| attackmate_msf_server          | hostname | **None** | Hostname of the Metasploit rpcd. (only needed for msf-commands) |
-| attackmate_msf_passwd          | password | **None** | Password for the Metasploit rpcd. (only needed for msf-commands) |
-| attackmate_playwright          | bool         | True | Whether to install Playwright and its dependencies |
-| command_delay                  | float | **None** | delay in seconds before commands for the CommandConfig |
-| attackmate_remote_config | dict | {} | Optional map of named remote AttackMate connections. Each entry requires url, username, password, and optionally cafile. If empty, no remote_config section is written to the config file. |
+| attackmate_url                 | url          | https://github.com/ait-aecid/attackmate.git | Official attackmate repository                         |
+| attackmate_version             | version-str  | main | Version/Branch of the Git-Repository in attackmate_url                                        |
+| attackmate_shared_dir          | path         | /usr/local/share                          | Installation path                                        |
+| attackmate_dest                | path         | `{{ attackmate_shared_dir }}/attackmate`  | Installation path of the attackmate repository           |
+| attackmate_sliverfix           | bool         | True                                      | [Install sliver-fix](https://aeciddocs.ait.ac.at/attackmate/development/installation/sliverfix.html#sliver-fix) |
+| attackmate_grpc_dest           | path         | `{{ attackmate_shared_dir }}/grpc`        | Temporary install grpc to this path if sliverfix is enabled |
+| attackmate_bindir              | path         | /usr/local/bin                            | Installpath for the tmux-wrapper                         |
+| attackmate_tmux                | bool         | True                                      | Deploy tmux-wrapper                                      |
+| attackmate_tmux_session        | str          | attackmate                                | Use this existing session-name for the tmux-wrapper      |
+| attackmate_tmux_window         | str          | attackmate                                | The name of the tmux-window for attackmate               |
+| attackmate_config_dir          | path         | /etc/attackmate                           | Path to the config-directory                             |
+| attackmate_playbook_path       | path         | `{{ attackmate_config_dir }}/playbooks`   | Path to the playbooks-directory                          |
+| attackmate_playbooks           | list of playbook-templates(j2) | `[]`                    | List of playbooks to deploy                              |
+| attackmate_config_tpl          | str          | attackmate.yml.j2 | Name of the config-template(jinja) |
+| attackmate_sliver_config       | path         | **None**                                  | Path to the generated sliver-config. (only needed for sliver-commands) |
+| attackmate_msf_server          | hostname     | **None**                                  | Hostname of the Metasploit rpcd. (only needed for msf-commands) |
+| attackmate_msf_passwd          | password     | **None**                                  | Password for the Metasploit rpcd. (only needed for msf-commands) |
+| attackmate_playwright          | bool         | True                                      | Whether to install Playwright and its dependencies |
+| command_delay                  | float        | **None**                                  | delay in seconds before commands for the CommandConfig |
+| attackmate_remote_config       | dict         | {} | Optional map of named remote AttackMate connections. Each entry requires url, username, password, and optionally cafile. If empty, no remote_config section is written to the config file.|
+| attackmate_api_server          | bool         | False                                     | Install the attackmate-api-server |
+| attackmate_api_server_url      | url          | https://github.com/ait-testbed/attackmate-api-server.git | Repository URL for the api server |
+| attackmate_api_server_version  | version-str  | main                                      | Version/Branch of the api server repository |
+| attackmate_api_server_dest     | path         | {{ attackmate_shared_dir }}/attackmate-api-server | Installation path of the api server |
 
 ## Example Playbook
 
@@ -65,6 +69,27 @@ This role installs to executables:
 
 * **/usr/local/bin/attackm8**: a wrapper for attackmate that uses the virtual environment
 * **/usr/local/bin/attackmate-tmux**: a wrapper that executes attackmate in a tmux-session
+
+## Installing as API Server
+
+AttackMate can optionally be installed together with the [AttackMate API Server](https://github.com/ait-testbed/attackmate-api-server),
+which exposes AttackMate's functionality via a REST API and allows remote instances to be controlled over the network.
+The API server is installed into the same virtual environment as AttackMate, since it depends on it.
+
+To enable the API server, set `attackmate_api_server: True` in your playbook:
+```yaml
+- name: Install attackmate with API server
+  become: true
+  hosts: localhost
+  roles:
+    - role: attackmate
+      vars:
+        attackmate_api_server: True
+```
+
+ installs to executables:
+
+* **/usr/local/bin/attackmate-api-server**: a wrapper for attackmate that uses the virtual environment
 
 ## Role testing with molecule
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,4 +51,16 @@ distribution_lower: "{{ ansible_distribution | lower }}"
 #     username: user
 #     password: anotherpassword
 #     cafile: "/path/to/another_cert.pem"
+
+# If no Remote AttackMate connections configured set to empty dict
 attackmate_remote_config: {}
+
+# Installation as api server
+attackmate_api_server: False
+attackmate_api_server_url: "https://github.com/ait-testbed/attackmate-api-server.git"
+attackmate_api_server_version: "main"
+attackmate_api_server_dest: "{{ attackmate_shared_dir }}/attackmate-api-server"
+
+attackmate_api_logs_to_disk: "False"
+attackmate_api_log_dir: "/var/log/attackmate-api"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,3 +64,8 @@ attackmate_api_server_dest: "{{ attackmate_shared_dir }}/attackmate-api-server"
 attackmate_api_logs_to_disk: "False"
 attackmate_api_log_dir: "/var/log/attackmate-api"
 
+attackmate_api_bin_path: "/usr/local/bin/attackmate-api"
+attackmate_api_service_path: "/etc/systemd/system/attackmate-api.service"
+attackmate_ssl_key_path: "/etc/ssl/private/attackmate.key"
+attackmate_ssl_cert_path: "/etc/ssl/certs/attackmate.pem"
+attackmate_api_server_port: 8445

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,7 +61,7 @@ attackmate_api_server_url: "https://github.com/ait-testbed/attackmate-api-server
 attackmate_api_server_version: "main"
 attackmate_api_server_dest: "{{ attackmate_shared_dir }}/attackmate-api-server"
 
-attackmate_api_logs_to_disk: "False"
+attackmate_api_logs_to_disk: False
 attackmate_api_log_dir: "/var/log/attackmate-api"
 
 attackmate_api_bin_path: "/usr/local/bin/attackmate-api"
@@ -69,3 +69,4 @@ attackmate_api_service_path: "/etc/systemd/system/attackmate-api.service"
 attackmate_ssl_key_path: "/etc/ssl/private/attackmate.key"
 attackmate_ssl_cert_path: "/etc/ssl/certs/attackmate.pem"
 attackmate_api_server_port: 8445
+attackmate_api_plain_users: {}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,6 @@
+- name: Restart attackmate-api
+  become: true
+  ansible.builtin.systemd:
+    name: attackmate-api
+    state: restarted
+    daemon_reload: yes

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,16 +9,8 @@ platforms:
     image: kalilinux/kali-rolling # Or a specific tagged version if preferred
     ansible_user: root
     pre_build_image: true          # Pulls image beforehand
-  - name: instance-ubuntu2204
-    image: ubuntu:22.04
-    ansible_user: root
-    pre_build_image: true
   - name: instance-ubuntu2404
     image: ubuntu:24.04
-    ansible_user: root
-    pre_build_image: true
-  - name: instance-debian12
-    image: debian:12
     ansible_user: root
     pre_build_image: true
   - name: instance-debian13

--- a/tasks/api_server.yml
+++ b/tasks/api_server.yml
@@ -1,0 +1,160 @@
+- name: Git checkout attackmate-api-server
+  ansible.builtin.git:
+    repo: "{{ attackmate_api_server_url }}"
+    dest: "{{ attackmate_api_server_dest }}"
+    version: "{{ attackmate_api_server_version }}"
+  tags:
+    - molecule-idempotence-notest
+
+- name: Install attackmate-api-server with uv
+  become: true
+  ansible.builtin.shell:
+    chdir: "{{ attackmate_api_server_dest }}"
+    cmd: "uv pip install --python {{ attackmate_dest }}/.venv/bin/python ."
+  tags:
+    - molecule-idempotence-notest
+
+- name: Create dedicated API service user
+  become: true
+  ansible.builtin.user:
+    name: attackmate-api
+    system: yes
+    shell: /usr/sbin/nologin
+    create_home: no
+
+- name: Create symlink for attackmate-api-server executable
+  become: true
+  ansible.builtin.file:
+    src: "{{ attackmate_dest }}/.venv/bin/attackmate-api"
+    dest: "/usr/local/bin/attackmate-api"
+    state: link
+    force: true
+
+- name: Get site-packages path from the venv
+  become: true
+  ansible.builtin.shell:
+    cmd: "{{ attackmate_dest }}/.venv/bin/python -c 'import site; print(site.getsitepackages()[0])'"
+  register: venv_site_packages
+  changed_when: false
+
+- name: Set API package destination path
+  ansible.builtin.set_fact:
+    api_package_path: "{{ venv_site_packages.stdout }}/attackmate_api_server"
+
+- name: Create API log directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ attackmate_api_log_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Ensure SSL directories exist with correct permissions
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: '/etc/ssl/private', mode: '0711' }
+    - { path: '/etc/ssl/certs', mode: '0755' }
+
+- name: Ensure OpenSSL is installed
+  ansible.builtin.package:
+    name: openssl
+    state: present
+
+- name: Generate Private Key
+  community.crypto.openssl_privatekey:
+    path: "/etc/ssl/private/attackmate.key"
+    type: RSA
+    size: 4096
+    owner: root
+    group: attackmate-api 
+    mode: '0640'
+
+- name: Generate Certificate Signing Request (CSR)
+  community.crypto.openssl_csr:
+    path: "/etc/ssl/private/attackmate.csr"
+    privatekey_path: "/etc/ssl/private/attackmate.key"
+    common_name: "{{ ansible_host }}"
+    subject_alt_name: "IP:{{ ansible_host }},DNS:localhost"
+
+- name: Generate Self-Signed Certificate
+  community.crypto.x509_certificate:
+    path: "/etc/ssl/certs/attackmate.pem"
+    privatekey_path: "/etc/ssl/private/attackmate.key"
+    csr_path: "/etc/ssl/private/attackmate.csr"
+    provider: selfsigned
+
+- name: Create .env file in project root
+  become: true
+  ansible.builtin.copy:
+    dest: "{{ attackmate_api_server_dest }}/.env"
+    content: |
+      SSL_KEY_PATH="/etc/ssl/private/attackmate.key"
+      SSL_CERT_PATH="/etc/ssl/certs/attackmate.pem"
+      ATTACKMATE_CONFIG_PATH="/etc/attackmate.yml"
+      WRITE_PLAYBOOK_LOGS_TO_DISK="{{ attackmate_api_logs_to_disk }}"
+      LOG_DIR="{{ attackmate_api_log_dir }}"
+    owner: attackmate-api
+    group: attackmate-api
+    mode: '0600' # Only the API user can read the secrets
+
+
+
+- name: Ensure API log directory is owned by the service user
+  become: true
+  ansible.builtin.file:
+    path: "{{ attackmate_api_log_dir }}"
+    state: directory
+    owner: attackmate-api
+    group: attackmate-api
+    mode: '0750'
+
+- name: Fix permissions on SSL keys for the service user
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: root
+    group: attackmate-api # Allow the API user to read the key
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: '/etc/ssl/private', mode: '0710' } 
+    - { path: '/etc/ssl/private/attackmate.key', mode: '0640' }
+    - { path: '/etc/ssl/certs/attackmate.pem', mode: '0644' }
+
+- name: Install AttackMate API Systemd service
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/attackmate-api.service
+    content: |
+      [Unit]
+      Description=AttackMate API Server
+      After=network.target
+
+      [Service]
+      Type=simple
+      User=attackmate-api
+      Group=attackmate-api
+      # This tells Pydantic where to look for the .env file
+      WorkingDirectory={{ attackmate_api_server_dest }}
+      ExecStart=/usr/local/bin/attackmate-api
+      Restart=always
+
+      NoNewPrivileges=yes
+      PrivateTmp=yes
+      ProtectSystem=full
+      ProtectHome=yes
+
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Start and enable AttackMate API
+  become: true
+  ansible.builtin.systemd:
+    name: attackmate-api
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/tasks/api_server.yml
+++ b/tasks/api_server.yml
@@ -1,19 +1,3 @@
-- name: Git checkout attackmate-api-server
-  ansible.builtin.git:
-    repo: "{{ attackmate_api_server_url }}"
-    dest: "{{ attackmate_api_server_dest }}"
-    version: "{{ attackmate_api_server_version }}"
-  tags:
-    - molecule-idempotence-notest
-
-- name: Install attackmate-api-server with uv
-  become: true
-  ansible.builtin.shell:
-    chdir: "{{ attackmate_api_server_dest }}"
-    cmd: "uv pip install --python {{ attackmate_dest }}/.venv/bin/python ."
-  tags:
-    - molecule-idempotence-notest
-
 - name: Create dedicated API service user
   become: true
   ansible.builtin.user:
@@ -22,30 +6,46 @@
     shell: /usr/sbin/nologin
     create_home: no
 
+# --- Git checkout ---
+
+- name: Git checkout attackmate-api-server
+  ansible.builtin.git:
+    repo: "{{ attackmate_api_server_url }}"
+    dest: "{{ attackmate_api_server_dest }}"
+    version: "{{ attackmate_api_server_version }}"
+  register: attackmate_api_git
+  tags:
+    - molecule-idempotence-notest
+
+# --- Installation ---
+
+- name: Install attackmate-api-server with uv
+  become: true
+  ansible.builtin.shell:
+    chdir: "{{ attackmate_api_server_dest }}"
+    cmd: "uv pip install --python {{ attackmate_dest }}/.venv/bin/python ."
+  when: attackmate_api_git.changed
+  changed_when: true
+  tags:
+    - molecule-idempotence-notest
+  notify: Restart attackmate-api
+
 - name: Create symlink for attackmate-api-server executable
   become: true
   ansible.builtin.file:
     src: "{{ attackmate_dest }}/.venv/bin/attackmate-api"
-    dest: "/usr/local/bin/attackmate-api"
+    dest: "{{ attackmate_api_bin_path }}"
     state: link
     force: true
 
-- name: Get site-packages path from the venv
-  become: true
-  ansible.builtin.shell:
-    cmd: "{{ attackmate_dest }}/.venv/bin/python -c 'import site; print(site.getsitepackages()[0])'"
-  register: venv_site_packages
-  changed_when: false
-
-- name: Set API package destination path
-  ansible.builtin.set_fact:
-    api_package_path: "{{ venv_site_packages.stdout }}/attackmate_api_server"
 
 - name: Create API log directory
   become: true
   ansible.builtin.file:
     path: "{{ attackmate_api_log_dir }}"
     state: directory
+    owner: attackmate-api
+    group: attackmate-api
     mode: '0755'
 
 - name: Ensure SSL directories exist with correct permissions
@@ -60,6 +60,8 @@
     - { path: '/etc/ssl/private', mode: '0711' }
     - { path: '/etc/ssl/certs', mode: '0755' }
 
+# --- SSL certificate generation ---
+
 - name: Ensure OpenSSL is installed
   ansible.builtin.package:
     name: openssl
@@ -67,68 +69,62 @@
 
 - name: Generate Private Key
   community.crypto.openssl_privatekey:
-    path: "/etc/ssl/private/attackmate.key"
+    path: "{{ attackmate_ssl_key_path }}"
     type: RSA
     size: 4096
     owner: root
-    group: attackmate-api 
+    group: attackmate-api
     mode: '0640'
-
-- name: Generate Certificate Signing Request (CSR)
-  community.crypto.openssl_csr:
-    path: "/etc/ssl/private/attackmate.csr"
-    privatekey_path: "/etc/ssl/private/attackmate.key"
-    common_name: "{{ ansible_host }}"
-    subject_alt_name: "IP:{{ ansible_host }},DNS:localhost"
+    # Only regenerate if the key is absent
+    regenerate: never
+  notify: Restart attackmate-api
 
 - name: Generate Self-Signed Certificate
   community.crypto.x509_certificate:
-    path: "/etc/ssl/certs/attackmate.pem"
-    privatekey_path: "/etc/ssl/private/attackmate.key"
-    csr_path: "/etc/ssl/private/attackmate.csr"
+    path: "{{ attackmate_ssl_cert_path }}"
+    privatekey_path: "{{ attackmate_ssl_key_path }}"
     provider: selfsigned
-
-- name: Create .env file in project root
-  become: true
-  ansible.builtin.copy:
-    dest: "{{ attackmate_api_server_dest }}/.env"
-    content: |
-      SSL_KEY_PATH="/etc/ssl/private/attackmate.key"
-      SSL_CERT_PATH="/etc/ssl/certs/attackmate.pem"
-      ATTACKMATE_CONFIG_PATH="/etc/attackmate.yml"
-      WRITE_PLAYBOOK_LOGS_TO_DISK="{{ attackmate_api_logs_to_disk }}"
-      LOG_DIR="{{ attackmate_api_log_dir }}"
-      # USERS='{"username": "<argon2_hash>", ...}' # You need to enter credentials here, hashed with argon2
-    owner: attackmate-api
-    group: attackmate-api
-    mode: '0600'
-
-
-- name: Ensure API log directory is owned by the service user
-  become: true
-  ansible.builtin.file:
-    path: "{{ attackmate_api_log_dir }}"
-    state: directory
-    owner: attackmate-api
-    group: attackmate-api
-    mode: '0750'
+    selfsigned_not_after: "+825d"
+    selfsigned_digest: sha256
+    subject:
+      CN: "{{ ansible_host }}"
+    subject_alt_name:
+      - "IP:{{ ansible_host }}"
+      - "DNS:localhost"
+    regenerate: never
+  notify: Restart attackmate-api
 
 - name: Fix permissions on SSL keys for the service user
   become: true
   ansible.builtin.file:
     path: "{{ item.path }}"
     owner: root
-    group: attackmate-api # Allow the API user to read the key
+    group: attackmate-api
     mode: "{{ item.mode }}"
   loop:
-    - { path: '/etc/ssl/private', mode: '0710' } 
-    - { path: '/etc/ssl/private/attackmate.key', mode: '0640' }
-    - { path: '/etc/ssl/certs/attackmate.pem', mode: '0644' }
+    - { path: '/etc/ssl/private', mode: '0710' }
+    - { path: "{{ attackmate_ssl_key_path }}", mode: '0640' }
+    - { path: "{{ attackmate_ssl_cert_path }}", mode: '0644' }
+
+
+# --- Env file ---
+
+- name: Create .env file in project root
+  become: true
+  ansible.builtin.template:
+    src: api-env.j2
+    dest: "{{ attackmate_api_server_dest }}/.env"
+    owner: attackmate-api
+    group: attackmate-api
+    mode: '0600'
+  notify: Restart attackmate-api
+
+# --- Systemd service ---
 
 - name: Install AttackMate API Systemd service
   become: true
   ansible.builtin.copy:
-    dest: /etc/systemd/system/attackmate-api.service
+    dest: "{{ attackmate_api_service_path }}"
     content: |
       [Unit]
       Description=AttackMate API Server
@@ -138,10 +134,9 @@
       Type=simple
       User=attackmate-api
       Group=attackmate-api
-      # This tells Pydantic where to look for the .env file
       WorkingDirectory={{ attackmate_api_server_dest }}
-      ExecStart=/usr/local/bin/attackmate-api
-      Restart=always
+      ExecStart={{ attackmate_api_bin_path }}
+      Restart=on-failure
 
       NoNewPrivileges=yes
       PrivateTmp=yes
@@ -150,11 +145,12 @@
 
       [Install]
       WantedBy=multi-user.target
+  notify: Restart attackmate-api
 
 - name: Start and enable AttackMate API
   become: true
   ansible.builtin.systemd:
     name: attackmate-api
-    state: restarted
+    state: started
     enabled: yes
     daemon_reload: yes

--- a/tasks/api_server.yml
+++ b/tasks/api_server.yml
@@ -98,10 +98,10 @@
       ATTACKMATE_CONFIG_PATH="/etc/attackmate.yml"
       WRITE_PLAYBOOK_LOGS_TO_DISK="{{ attackmate_api_logs_to_disk }}"
       LOG_DIR="{{ attackmate_api_log_dir }}"
+      # USERS='{"username": "<argon2_hash>", ...}' # You need to enter credentials here, hashed with argon2
     owner: attackmate-api
     group: attackmate-api
-    mode: '0600' # Only the API user can read the secrets
-
+    mode: '0600'
 
 
 - name: Ensure API log directory is owned by the service user

--- a/tasks/api_server.yml
+++ b/tasks/api_server.yml
@@ -111,6 +111,34 @@
     - { path: "{{ attackmate_ssl_key_path }}", mode: '0640' }
     - { path: "{{ attackmate_ssl_cert_path }}", mode: '0644' }
 
+# --- User hashes for .env file (Optional) ---
+
+- name: Install argon2-cffi for hash generation
+  ansible.builtin.pip:
+    name: argon2-cffi
+    state: present
+  delegate_to: localhost
+  become: false
+  when: attackmate_api_plain_users | length > 0
+
+- name: Generate argon2 hashes for API users
+  ansible.builtin.shell:
+    cmd: "python3 -c \"from argon2 import PasswordHasher; ph = PasswordHasher(); print(ph.hash('{{ item.value }}'))\""
+  loop: "{{ attackmate_api_plain_users | dict2items }}"
+  register: argon2_hashes
+  changed_when: false
+  delegate_to: localhost
+  become: false
+  #no_log: true
+  when: attackmate_api_plain_users | length > 0
+
+- name: Build USERS json string
+  ansible.builtin.set_fact:
+    attackmate_api_users: >-
+      {{ dict(argon2_hashes.results | map(attribute='item.key') |
+      zip(argon2_hashes.results | map(attribute='stdout'))) | to_json }}
+  #no_log: true
+  when: attackmate_api_plain_users | length > 0
 
 # --- Env file ---
 

--- a/tasks/api_server.yml
+++ b/tasks/api_server.yml
@@ -79,20 +79,25 @@
     regenerate: never
   notify: Restart attackmate-api
 
+- name: Generate Certificate Signing Request (CSR)
+  community.crypto.openssl_csr:
+    path: "/etc/ssl/private/attackmate.csr"
+    privatekey_path: "{{ attackmate_ssl_key_path }}"
+    common_name: "{{ ansible_host }}"
+    subject_alt_name:
+      - "IP:{{ ansible_host }}"
+      - "DNS:localhost"
+    force: false
+
 - name: Generate Self-Signed Certificate
   community.crypto.x509_certificate:
     path: "{{ attackmate_ssl_cert_path }}"
     privatekey_path: "{{ attackmate_ssl_key_path }}"
+    csr_path: "/etc/ssl/private/attackmate.csr"
     provider: selfsigned
     selfsigned_not_after: "+825d"
     selfsigned_digest: sha256
-    subject:
-      CN: "{{ ansible_host }}"
-    subject_alt_name:
-      - "IP:{{ ansible_host }}"
-      - "DNS:localhost"
-    regenerate: never
-  notify: Restart attackmate-api
+
 
 - name: Fix permissions on SSL keys for the service user
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -156,3 +156,12 @@
       tags:
         - playwright
   when: attackmate_playwright
+
+- name: Include api_server setup
+  ansible.builtin.include_tasks:
+    file: "api_server.yml"
+    apply:
+      tags:
+        - api_server
+  when: attackmate_api_server
+

--- a/tasks/sliverfix.yml
+++ b/tasks/sliverfix.yml
@@ -10,17 +10,25 @@
     - pip
     - grpc
 
+- name: Inspect HTTP Headers for caching logic
+  ansible.builtin.debug:
+    msg: 
+      - "Status Code: {{ download_result.status_code }}"
+      - "ETag: {{ download_result.etag | default('Not Present') }}"
+      - "Last-Modified: {{ download_result.last_modified | default('Not Present') }}"
+      - "Full Response: {{ download_result }}"
+
 - name: Read the .whl URL from the 'current' file
   ansible.builtin.slurp:
     src: "/tmp/current"
   register: current_file_content
-  when: download_result.status_code | default(404) == 200
+  when: (download_result.status_code | default(404)) | int in [200, 304]
 
 - name: Set fact with the extracted .whl URL
   ansible.builtin.set_fact:
     grpc_whl_download_url: "{{ current_file_content['content'] | b64decode | trim }}"
   when:
-    - download_result.status_code | default(404) == 200
+    - (download_result.status_code | default(404)) | int in [200, 304]
     - current_file_content.content is defined
     - current_file_content.content | b64decode | trim != '' # Ensure the content is not empty after decoding/trimming
 
@@ -45,7 +53,7 @@
   ansible.builtin.shell:
     chdir: "{{ attackmate_dest }}"
     cmd: "uv pip install --python {{ attackmate_dest }}/.venv/bin/python /tmp/{{ grpc_whl_filename }}"
-  when: download_result.status_code | default(404) == 200
+  when: (download_result.status_code | default(404)) | int in [200, 304]
   tags:
     - install
     - pip
@@ -56,7 +64,7 @@
     msg:
     - "No grpc patch available falling back to compile locally"
     - "This will take a while depending on your system"
-  when: download_result.status_code | default(403) != 200
+  when: (download_result.status_code | default(403)) | int not in [200, 304]
 
 - name: Git checkout grpc
   ansible.builtin.git:
@@ -64,7 +72,7 @@
     dest: "{{ attackmate_grpc_dest }}"
     recursive: yes
     update: yes  
-  when: download_result.status_code | default(404) != 200
+  when: (download_result.status_code | default(404)) | int not in [200, 304]
 
 - name: Install packages for sliverfix
   become: true
@@ -73,7 +81,7 @@
   tags:
     - install
     - dependencies
-  when: download_result.status_code | default(404) != 200
+  when: (download_result.status_code | default(404)) | int not in [200, 304]
 
 - name: Create virtual environment with uv
   become: true
@@ -85,7 +93,7 @@
   tags:
     - install
     - pip
-  when: download_result.status_code | default(404) != 200
+  when: (download_result.status_code | default(404)) | int not in [200, 304]
 
 - name: Install Python dependencies using uv
   ansible.builtin.shell:
@@ -95,7 +103,7 @@
     - install
     - pip
     - grpc
-  when: download_result.status_code | default(404) != 200
+  when: (download_result.status_code | default(404)) | int not in [200, 304]
 
 - name: Compile and install grpc to attackmate
   ansible.builtin.shell:
@@ -105,7 +113,7 @@
     - install
     - pip
     - grpc
-  when: download_result.status_code | default(404) != 200
+  when: (download_result.status_code | default(404)) | int not in [200, 304]
 
 - name: Remove grpc dev-files
   ansible.builtin.shell:
@@ -114,7 +122,7 @@
     - install
     - pip
     - grpc
-  when: download_result.status_code | default(404) != 200
+  when: (download_result.status_code | default(404)) | int not in [200, 304]
 
 - name: Lock sliverfix
   ansible.builtin.shell:

--- a/tasks/sliverfix.yml
+++ b/tasks/sliverfix.yml
@@ -1,6 +1,11 @@
+- name: Get Python version cp-tag from attackmate venv
+  ansible.builtin.shell:
+    cmd: "{{ attackmate_dest }}/.venv/bin/python -c \"import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')\""
+  register: cp_tag
+
 - name: Download the 'current' file containing the .whl URL
   ansible.builtin.get_url:
-    url: "{{ grpc_patch_url }}" # This should be the URL to the 'current' file, e.g., https://aecidimages.ait.ac.at/EXTRA/grpc/debian/12/x86_64/current
+    url: "{{ grpc_patch_url }}/{{ cp_tag.stdout }}/current" # This is the URL to the 'current' file, e.g., https://aecidimages.ait.ac.at/EXTRA/grpc/debian/13/x86_64/cp312/current
     dest: "/tmp/current"
     mode: '0644'
   register: download_result
@@ -9,14 +14,6 @@
     - install
     - pip
     - grpc
-
-- name: Inspect HTTP Headers for caching logic
-  ansible.builtin.debug:
-    msg: 
-      - "Status Code: {{ download_result.status_code }}"
-      - "ETag: {{ download_result.etag | default('Not Present') }}"
-      - "Last-Modified: {{ download_result.last_modified | default('Not Present') }}"
-      - "Full Response: {{ download_result }}"
 
 - name: Read the .whl URL from the 'current' file
   ansible.builtin.slurp:

--- a/templates/api-env.j2
+++ b/templates/api-env.j2
@@ -4,6 +4,8 @@ ATTACKMATE_CONFIG_PATH="/etc/attackmate.yml"
 WRITE_PLAYBOOK_LOGS_TO_DISK="{{ attackmate_api_logs_to_disk }}"
 LOG_DIR="{{ attackmate_api_log_dir }}"
 ATTACKMATE_API_SERVER_PORT="{{ attackmate_api_server_port }}"
-{% if attackmate_api_users is defined %}
+{% if attackmate_api_users is defined and attackmate_api_users %}
 USERS='{{ attackmate_api_users }}'
+{% elif attackmate_api_plain_users | length == 0 %}
+# No users configured — set USERS here or re-run with attackmate_api_plain_users defined
 {% endif %}

--- a/templates/api-env.j2
+++ b/templates/api-env.j2
@@ -4,5 +4,6 @@ ATTACKMATE_CONFIG_PATH="/etc/attackmate.yml"
 WRITE_PLAYBOOK_LOGS_TO_DISK="{{ attackmate_api_logs_to_disk }}"
 LOG_DIR="{{ attackmate_api_log_dir }}"
 ATTACKMATE_API_SERVER_PORT="{{ attackmate_api_server_port }}"
+{% if attackmate_api_users is defined %}
 USERS='{{ attackmate_api_users }}'
 {% endif %}

--- a/templates/api-env.j2
+++ b/templates/api-env.j2
@@ -1,0 +1,8 @@
+SSL_KEY_PATH="{{ attackmate_ssl_key_path }}"
+SSL_CERT_PATH="{{ attackmate_ssl_cert_path }}"
+ATTACKMATE_CONFIG_PATH="/etc/attackmate.yml"
+WRITE_PLAYBOOK_LOGS_TO_DISK="{{ attackmate_api_logs_to_disk }}"
+LOG_DIR="{{ attackmate_api_log_dir }}"
+ATTACKMATE_API_SERVER_PORT="{{ attackmate_api_server_port }}"
+USERS='{{ attackmate_api_users }}'
+{% endif %}

--- a/vars/debian12.yml
+++ b/vars/debian12.yml
@@ -3,4 +3,4 @@ playwright_dependencies:
   - libnss3
   - libnspr4
   
-grpc_patch_url: "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current"
+grpc_patch_url: "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}"

--- a/vars/debian13.yml
+++ b/vars/debian13.yml
@@ -16,4 +16,4 @@ playwright_dependencies:
     - fonts-unifont
     - libasound2
 
-grpc_patch_url: "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current"
+grpc_patch_url: "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}"

--- a/vars/kali.yml
+++ b/vars/kali.yml
@@ -14,4 +14,4 @@ playwright_dependencies:
       - libgbm1
       - libxkbcommon0
 
-grpc_patch_url:  "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_version }}/{{ ansible_architecture }}/current"
+grpc_patch_url:  "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_version }}/{{ ansible_architecture }}"

--- a/vars/ubuntu22.04.yml
+++ b/vars/ubuntu22.04.yml
@@ -3,4 +3,4 @@ playwright_dependencies:
   - libnss3
   - libnspr4
 
-grpc_patch_url: "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_version }}/{{ ansible_architecture }}/current"
+grpc_patch_url: "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_version }}/{{ ansible_architecture }}"

--- a/vars/ubuntu24.04.yml
+++ b/vars/ubuntu24.04.yml
@@ -3,4 +3,4 @@ playwright_dependencies:
   - libnss3
   - libnspr4
 
-grpc_patch_url: "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_version }}/{{ ansible_architecture }}/current"
+grpc_patch_url: "{{ grpc_download_base_url }}/{{ distribution_lower }}/{{ ansible_distribution_version }}/{{ ansible_architecture }}"


### PR DESCRIPTION
Add attackmate-api-server role support, #10 
also solves #12 


Adds optional deployment of the attackmate-api-server as a systemd service.

- New tasks to checkout, install, and configure the API server via `uv` **into the existing attackmate venv**
- Dedicated `attackmate-api` system user with minimal privileges
-  self-signed TLS certificate generation
- Systemd service unit
- Automated argon2 password hashing at deploy time via `attackmate_api_plain_users`
- `.env` file management via Jinja2 template

Usage
Set `attackmate_api_server: true` and optionally define `attackmate_api_plain_users` in a local, untracked vars file.

 API server is opt-in and disabled by default


Full api server implementation is not in the attackmate main repo/branch yet
For testing use:
**attackmate_url: "https://github.com/thorinaboenke/attackmate"
attackmate_version: "_api_refactor"**