### PR TITLE
changed example name of attackmate-remote-api server

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Note on gRPC: To ensure high performance and fast deployment, pre-compiled Pytho
           - attackchain.j2
         command_delay: 2
         attackmate_remote_config:
-          primary_node:
+          attackmate-server:
             url: "https://10.0.0.5:8445"
             username: admin
             password: securepassword

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,19 +39,6 @@ attackmate_playwright_pip_packages:  # Python packages to install into the Attac
 grpc_download_base_url: "https://aecidimages.ait.ac.at/EXTRA/grpc"
 distribution_lower: "{{ ansible_distribution | lower }}"
 
-# Remote AttackMate connections (optional)
-# attackmate_remote_config:
-#   remote_server:
-#     url: "https://10.0.0.5:5000"
-#     username: admin
-#     password: securepassword
-#     cafile: "/path/to/cert.pem"
-#   another_server:
-#     url: "https://10.0.0.6:5000"
-#     username: user
-#     password: anotherpassword
-#     cafile: "/path/to/another_cert.pem"
-
 # If no Remote AttackMate connections configured set to empty dict
 attackmate_remote_config: {}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,7 +132,7 @@
 
 - name: Test sliverfix-lock
   ansible.builtin.shell:
-    cmd: "test -e {{ attackmate_dest }}/venv/.sliverfix"
+    cmd: "test -e {{ attackmate_dest }}/.venv/.sliverfix"
   register: sliverfix_result
   failed_when: sliverfix_result.stderr == "Error"
   tags:


### PR DESCRIPTION
fixed typo in sliverfix check, removed remote config commentary from defaults.
changed example name of attackmate-remote-api server from "primary_node" to "attackmate-server".